### PR TITLE
TIM-1039 Feat: Update blog document types to use TitleField for title

### DIFF
--- a/customtypes/blog/index.json
+++ b/customtypes/blog/index.json
@@ -18,7 +18,7 @@
           "label": "Title",
           "placeholder": "",
           "allowTargetBlank": true,
-          "single": "heading1,paragraph"
+          "single": "heading1"
         }
       },
       "image": {

--- a/prismicio-types.d.ts
+++ b/prismicio-types.d.ts
@@ -13,13 +13,13 @@ interface BlogDocumentData {
   /**
    * Title field in *Blog*
    *
-   * - **Field Type**: Rich Text
+   * - **Field Type**: Title
    * - **Placeholder**: *None*
    * - **API ID Path**: blog.title
    * - **Tab**: Main
    * - **Documentation**: https://prismic.io/docs/field#rich-text-title
    */
-  title: prismic.RichTextField;
+  title: prismic.TitleField;
 
   /**
    * Image field in *Blog*


### PR DESCRIPTION
This pull request includes a small change to the `customtypes/blog/index.json` file. The change modifies the `single` property of the `Title` field to only allow "heading1" instead of "heading1,paragraph".

- `main` <!-- branch-stack -->
  - \#67 :point\_left:
    - \#68
      - \#69
        - \#70
