### PR TITLE
TIM-1054 Fix: Remove dark mode classes from ContentComponent for cleaner styling

### DIFF
--- a/src/app/blog/[uid]/BlogPost.tsx
+++ b/src/app/blog/[uid]/BlogPost.tsx
@@ -108,7 +108,7 @@ const BlogPost = async ({ uid }: { uid: string }) => {
 					))}
 				</div> */}
         </div>
-        <div className="prose prose-lg dark:prose-invert mx-auto mt-20 w-full max-w-lg">
+        <div className="mt-20 prose prose-lg mx-auto w-full max-w-lg">
           <PrismicRichText field={content} components={Component} />
         </div>
       </Container>

--- a/src/app/blog/[uid]/ContentComponent.tsx
+++ b/src/app/blog/[uid]/ContentComponent.tsx
@@ -3,59 +3,55 @@ import { JSXMapSerializer } from '@prismicio/react';
 
 export const Component: JSXMapSerializer = {
   heading1: ({ children }) => (
-    <h1 className="mt-8 mb-4 text-4xl leading-tight font-bold md:text-5xl dark:text-inherit">
+    <h1 className="mt-8 mb-4 text-4xl font-bold leading-tight md:text-5xl">
       {children}
     </h1>
   ),
   heading2: ({ children }) => (
-    <h2 className="mt-6 mb-3 text-3xl font-semibold md:text-4xl dark:text-inherit">
+    <h2 className="mt-6 mb-3 text-3xl font-semibold md:text-4xl">
       {children}
     </h2>
   ),
   heading3: ({ children }) => (
-    <h3 className="mt-4 mb-2 text-2xl font-medium md:text-3xl dark:text-inherit">
+    <h3 className="mt-4 mb-2 text-2xl font-medium md:text-3xl">
       {children}
     </h3>
   ),
   paragraph: ({ children }) => (
-    <p className="mb-6 text-base leading-relaxed text-gray-800 dark:text-gray-200">
-      {children}
-    </p>
+    <p className="mb-6 text-base leading-relaxed text-gray-800">{children}</p>
   ),
   oList: ({ children }) => (
-    <ol className="mb-6 list-decimal space-y-3 pl-6 text-base text-gray-800 dark:text-gray-200">
+    <ol className="mb-6 pl-6 space-y-3 text-base text-gray-800 list-decimal">
       {children}
     </ol>
   ),
   oListItem: ({ children }) => (
-    <li className="mb-2 pl-2 text-base text-gray-800 marker:text-gray-500 dark:text-gray-200 dark:marker:text-gray-400">
+    <li className="mb-2 pl-2 text-base text-gray-800 marker:text-gray-500">
       {children}
     </li>
   ),
   list: ({ children }) => (
-    <ul className="mb-6 list-disc space-y-3 pl-6 text-base text-gray-800 dark:text-gray-200">
+    <ul className="mb-6 pl-6 space-y-3 text-base text-gray-800 list-disc">
       {children}
     </ul>
   ),
   listItem: ({ children }) => (
-    <li className="mb-2 pl-2 text-base text-gray-800 marker:text-gray-500 dark:text-gray-200 dark:marker:text-gray-400">
+    <li className="mb-2 pl-2 text-base text-gray-800 marker:text-gray-500">
       {children}
     </li>
   ),
   preformatted: ({ children }) => (
-    <pre className="mb-6 overflow-x-auto rounded-lg bg-gray-50 p-4 text-sm md:p-6 md:text-base dark:bg-gray-800/50">
+    <pre className="p-4 mb-6 overflow-x-auto text-sm bg-gray-50 rounded-lg md:p-6 md:text-base">
       <code className="font-mono">{children}</code>
     </pre>
   ),
   strong: ({ children }) => (
-    <strong className="font-semibold text-gray-900 dark:text-gray-100">
-      {children}
-    </strong>
+    <strong className="font-semibold text-gray-900">{children}</strong>
   ),
   hyperlink: ({ children, node }) => (
     <PrismicNextLink
       field={node.data}
-      className="hover:text-primary-600 dark:hover:text-primary-400 underline decoration-1 underline-offset-2 transition-colors"
+      className="underline decoration-1 underline-offset-2 hover:text-primary-600 transition-colors"
     >
       {children}
     </PrismicNextLink>


### PR DESCRIPTION
This pull request includes changes to the `src/app/blog/[uid]/BlogPost.tsx` and `src/app/blog/[uid]/ContentComponent.tsx` files to remove dark mode styling. The most important changes are as follows:

Styling updates:

- Removed dark mode styling from the `BlogPost` component's main content container. (`src/app/blog/[uid]/BlogPost.tsx`) ([src/app/blog/\[uid\]/BlogPost.tsxL111-R111](diffhunk://#diff-8cad48a0305436f72a00b0ec0e708ff6a0ce9b3249588fea2ab0bb0e84ab8507L111-R111))
- Removed dark mode styling from various elements in the `ContentComponent` including headings, paragraphs, lists, list items, preformatted text, strong text, and hyperlinks. (`src/app/blog/[uid]/ContentComponent.tsx`) ([src/app/blog/\[uid\]/ContentComponent.tsxL6-R58](diffhunk://#diff-596d0c7588cfbba6cae74be4a242a65b4ea483aab62e114c6ad71e439dbe297eL6-R58))

* `main` <!-- branch-stack -->
  - \#83 :point\_left:
